### PR TITLE
Allow to export nyc coverage from jasmine-browser-runner

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ async function createReporters(options, deps) {
     consoleReporter.setOptions({
       color: options.color,
       alwaysListPendingSpecs: options.alwaysListPendingSpecs,
-      identifier: options.identifier,
+      nycPath: options['nyc-path'],
+      nycIdentifier: options['nyc-identifier'],
     });
     result.push(consoleReporter);
   }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ async function createReporters(options, deps) {
     consoleReporter.setOptions({
       color: options.color,
       alwaysListPendingSpecs: options.alwaysListPendingSpecs,
+      identifier: options.identifier,
     });
     result.push(consoleReporter);
   }

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ async function createReporters(options, deps) {
     consoleReporter.setOptions({
       color: options.color,
       alwaysListPendingSpecs: options.alwaysListPendingSpecs,
-      nycPath: options['nyc-path'],
-      nycIdentifier: options['nyc-identifier'],
+      nycPath: options.nycPath,
+      nycIdentifier: options.nycIdentifier,
     });
     result.push(consoleReporter);
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -80,6 +80,11 @@ const subCommands = [
         type: 'string',
         description: 'which local browser to launch',
       },
+      {
+        name: 'identifier',
+        type: 'string',
+        description: 'identifier (used by the coverage report)',
+      },
     ]),
   },
 ];

--- a/lib/command.js
+++ b/lib/command.js
@@ -81,7 +81,12 @@ const subCommands = [
         description: 'which local browser to launch',
       },
       {
-        name: 'identifier',
+        name: 'nyc-path',
+        type: 'string',
+        description: 'path (used by the coverage report)',
+      },
+      {
+        name: 'nyc-identifier',
         type: 'string',
         description: 'identifier (used by the coverage report)',
       },

--- a/lib/console_reporter.js
+++ b/lib/console_reporter.js
@@ -86,7 +86,7 @@ function ConsoleReporter() {
   };
 
   this.nycCoverage = function(result) {
-    const directoryPath = '/tmp/nyc';
+    const directoryPath = '/build/engage-digital/tmp/nyc';
     const path = `${directoryPath}/${identifier}.json`
 
     if (!fs.existsSync(directoryPath)) {

--- a/lib/console_reporter.js
+++ b/lib/console_reporter.js
@@ -86,7 +86,7 @@ function ConsoleReporter() {
   };
 
   this.nycCoverage = function(result) {
-    const directoryPath = '/build/engage-digital/tmp/nyc';
+    const directoryPath = '/builds/engage-digital/tmp/nyc';
     const path = `${directoryPath}/${identifier}.json`
 
     if (!fs.existsSync(directoryPath)) {

--- a/lib/console_reporter.js
+++ b/lib/console_reporter.js
@@ -1,4 +1,5 @@
 const util = require('util');
+const fs = require('fs');
 module.exports = exports = ConsoleReporter;
 
 /**
@@ -30,6 +31,7 @@ function ConsoleReporter() {
       none: '\x1B[0m',
     },
     failedSuites = [],
+    identifier = 'unknown',
     stackFilter = defaultStackFilter;
 
   /**
@@ -56,6 +58,10 @@ function ConsoleReporter() {
       showColors = options.color;
     }
 
+    if (options.identifier !== undefined) {
+      identifier = options.identifier;
+    }
+
     if (options.jasmineCorePath) {
       jasmineCorePath = options.jasmineCorePath;
     }
@@ -77,6 +83,26 @@ function ConsoleReporter() {
     }
     print('Started');
     printNewline();
+  };
+
+  this.nycCoverage = function(result) {
+    const directoryPath = '/tmp/nyc';
+    const path = `${directoryPath}/${identifier}.json`
+
+    if (!fs.existsSync(directoryPath)) {
+      fs.mkdirSync(directoryPath);
+    }
+
+    printNewline();
+    printNewline();
+    print(`Coverage saved to ${path}`);
+
+
+    fs.writeFile(path, JSON.stringify(result), (err) => {
+      if (err) {
+        print(`Error: ${err}`);
+      }
+    });
   };
 
   this.jasmineDone = function(result) {

--- a/lib/console_reporter.js
+++ b/lib/console_reporter.js
@@ -31,7 +31,8 @@ function ConsoleReporter() {
       none: '\x1B[0m',
     },
     failedSuites = [],
-    identifier = 'unknown',
+    nycPath = '/tmp/nyc',
+    nycIdentifier = 'unknown',
     stackFilter = defaultStackFilter;
 
   /**
@@ -58,8 +59,12 @@ function ConsoleReporter() {
       showColors = options.color;
     }
 
-    if (options.identifier !== undefined) {
-      identifier = options.identifier;
+    if (options.nycPath !== undefined) {
+      nycPath = options.nycPath;
+    }
+
+    if (options.nycIdentifier !== undefined) {
+      nycIdentifier = options.nycIdentifier;
     }
 
     if (options.jasmineCorePath) {
@@ -86,8 +91,8 @@ function ConsoleReporter() {
   };
 
   this.nycCoverage = function(result) {
-    const directoryPath = '/builds/engage-digital/tmp/nyc';
-    const path = `${directoryPath}/${identifier}.json`
+    const directoryPath = nycPath;
+    const path = `${directoryPath}/${nycIdentifier}.json`;
 
     if (!fs.existsSync(directoryPath)) {
       fs.mkdirSync(directoryPath);

--- a/lib/support/batchReporter.js
+++ b/lib/support/batchReporter.js
@@ -21,6 +21,7 @@ function BatchReporter() {
   };
 
   this.jasmineDone = function(info) {
+    events.push(['coverage', __coverage__]);
     events.push(['jasmineDone', info]);
   };
 

--- a/lib/support/batchReporter.js
+++ b/lib/support/batchReporter.js
@@ -21,7 +21,9 @@ function BatchReporter() {
   };
 
   this.jasmineDone = function(info) {
-    events.push(['nycCoverage', __coverage__]);
+    if (typeof __coverage__ !== 'undefined') {
+      events.push(['nycCoverage', __coverage__]);
+    }
     events.push(['jasmineDone', info]);
   };
 

--- a/lib/support/batchReporter.js
+++ b/lib/support/batchReporter.js
@@ -21,7 +21,7 @@ function BatchReporter() {
   };
 
   this.jasmineDone = function(info) {
-    events.push(['coverage', __coverage__]);
+    events.push(['nycCoverage', __coverage__]);
     events.push(['jasmineDone', info]);
   };
 

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -23,7 +23,7 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
           '--no-sandbox',
           'window-size=1024,768',
           '--disable-gpu',
-          'disable-dev-shm-usage',
+          '--disable-dev-shm-usage',
         ],
       });
       return webdriverBuilder

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -23,6 +23,7 @@ function buildWebdriver(browserInfo, webdriverBuilder) {
           '--no-sandbox',
           'window-size=1024,768',
           '--disable-gpu',
+          'disable-dev-shm-usage',
         ],
       });
       return webdriverBuilder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-browser-runner",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Serve and run your Jasmine specs in a browser",
   "bin": "bin/jasmine-browser-runner",
   "exports": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-browser-runner",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Serve and run your Jasmine specs in a browser",
   "bin": "bin/jasmine-browser-runner",
   "exports": "./index.js",


### PR DESCRIPTION
add nyc-path and nyc-identifier to export nyc coverage report